### PR TITLE
Generic Bugfixes

### DIFF
--- a/examples/USB/USB.ino
+++ b/examples/USB/USB.ino
@@ -47,7 +47,7 @@ void loop() {
 	// Check if new pattern received
 	if (pattern != lastPattern) {
 		lastPattern = pattern;  // Save pattern for reference
-		leds.receivePattern(lastPattern);  // Set pattern and use linked pattern features
+		leds.linkPattern(lastPattern);  // Set pattern and use linked pattern features
 	}
 	
 	leds.run();

--- a/keywords.txt
+++ b/keywords.txt
@@ -25,7 +25,7 @@ begin	KEYWORD2
 
 # Set Functions
 setPattern	KEYWORD2
-receivePattern	KEYWORD2
+linkPattern	KEYWORD2
 
 # Get Functions
 getPattern	KEYWORD2

--- a/src/X360ControllerLEDs.cpp
+++ b/src/X360ControllerLEDs.cpp
@@ -28,6 +28,30 @@
 
 namespace Xbox360Controller_LEDs {
 
+static const boolean isPlayerFlash(LED_Pattern pattern) {
+	switch (pattern) {
+	case(LED_Pattern::Flash1):
+	case(LED_Pattern::Flash2):
+	case(LED_Pattern::Flash3):
+	case(LED_Pattern::Flash4):
+		return true;
+	default:
+		return false;
+	}
+}
+
+static const boolean isPlayerSolid(LED_Pattern pattern) {
+	switch (pattern) {
+	case(LED_Pattern::Player1):
+	case(LED_Pattern::Player2):
+	case(LED_Pattern::Player3):
+	case(LED_Pattern::Player4):
+		return true;
+	default:
+		return false;
+	}
+}
+
 // Dummy animation to populate the currentAnimation pointer
 static const LED_Animation<1> Animation_Null(
 	{ LED_Frame(0, 0) },  // No LEDs lit, infinite frame duration
@@ -58,6 +82,7 @@ void XboxLEDHandler::linkPattern(LED_Pattern pattern) {
 void XboxLEDHandler::setPattern(LED_Pattern pattern, boolean runNow) {
 	if (currentPattern == pattern) return;  // No change
 	if (runNow == false && pattern == currentAnimation->Next) return;  // That's the next pattern! We'll get there...
+	if (linkPatterns && isPlayerFlash(pattern) && isPlayerSolid(currentPattern)) return;  // Don't go back to flashing if player is solid
 
 	// If pattern says go back, load prevous pattern
 	if (pattern == LED_Pattern::Previous) {

--- a/src/X360ControllerLEDs.cpp
+++ b/src/X360ControllerLEDs.cpp
@@ -49,7 +49,7 @@ void XboxLEDHandler::setPattern(LED_Pattern pattern) {
 	setPattern(pattern, true);  // Screw it, do the pattern NOW
 }
 
-void XboxLEDHandler::receivePattern(LED_Pattern pattern) {
+void XboxLEDHandler::linkPattern(LED_Pattern pattern) {
 	if ((uint8_t)pattern >= XboxLEDHandler::NumPatterns) return;  // Meta pattern, ignore
 	linkPatterns = true;  // Auto-link to the next pattern if available
 	setPattern(pattern, false);  // Set pattern, but don't run immediately if it is next pattern in queue

--- a/src/X360ControllerLEDs.cpp
+++ b/src/X360ControllerLEDs.cpp
@@ -302,8 +302,8 @@ const LED_Animation<1> XboxLEDAnimations<4>::Anim_Player4 ({
 const LED_Animation<4> XboxLEDAnimations<4>::Anim_Rotating ({
 	LED_Frame(XboxLEDAnimations<4>::States_Player1, XboxLEDAnimations<4>::RotateTime),
 	LED_Frame(XboxLEDAnimations<4>::States_Player2, XboxLEDAnimations<4>::RotateTime),
-	LED_Frame(XboxLEDAnimations<4>::States_Player3, XboxLEDAnimations<4>::RotateTime),
-	LED_Frame(XboxLEDAnimations<4>::States_Player4, XboxLEDAnimations<4>::RotateTime)},
+	LED_Frame(XboxLEDAnimations<4>::States_Player4, XboxLEDAnimations<4>::RotateTime),
+	LED_Frame(XboxLEDAnimations<4>::States_Player3, XboxLEDAnimations<4>::RotateTime)},
 	50,  // Rotate 50 times
 	LED_Pattern::Previous  // After rotating, go back to previous
 );

--- a/src/X360ControllerLEDs.h
+++ b/src/X360ControllerLEDs.h
@@ -217,7 +217,7 @@ namespace Xbox360Controller_LEDs {
 		virtual void begin() = 0;
 
 		void setPattern(LED_Pattern pattern);
-		void receivePattern(LED_Pattern pattern);
+		void linkPattern(LED_Pattern pattern);
 
 		LED_Pattern getPattern() const;
 

--- a/src/X360ControllerLEDs.h
+++ b/src/X360ControllerLEDs.h
@@ -268,6 +268,7 @@ namespace Xbox360Controller_LEDs {
 		void begin() {  // Initialize LED outputs
 			for (uint8_t i = 0; i < NumLEDs; i++) {
 				pinMode(Pins[i], OUTPUT);
+				digitalWrite(Pins[i], Inverted);  // Set 'off' immediately
 			}
 			setPattern(LED_Pattern::Off);
 		}


### PR DESCRIPTION
First batch of bugfixes for the public library!

* **Fix the rotating pattern LED order**: on the controller this is 1-2-4-3 so that the LEDs 'spin' around the center circle. I had set this as 1-2-3-4 because I was testing with a straight line of LEDs. Oops.
* **Initialize all pins as 'off'**: rather than waiting for the `setLEDs` function to eventually be called from `begin`, it made sense to initialize the LEDs to a known state before doing any processing. Just in case I want to optimize that later.
* **Rename `receivePattern` to `linkPattern`**: the new name better describes what the function *does* rather than when it's most often used, which is significantly more useful at a glance.

    I know changing a public function name technically breaks semantic versioning because I released it as 1.0.0, meaning this "should" be 2.0.0 now, but meh. It's only been live for a week now - everything will be fine.

* **Prevent regressing to player flash when using linked patterns**: the driver typically sends a 'flash' pattern followed quickly by a 'solid' pattern when the player number is assigned, but occasionally it will only send 'flash' or the microcontroller will drop the 'solid' pattern. When the library automatically links to the solid animation, the `linkPattern` function will re-assign the flash pattern and the LED will blink indefinitely. This prevents the LED from going back to flashing unless the user uses the `setPattern` function.