### PR TITLE
Pause Output

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -35,6 +35,10 @@ getNumLEDs	KEYWORD2
 getLastFrame	KEYWORD2
 rewriteFrame	KEYWORD2
 
+# Output State
+pauseOutput	KEYWORD2
+resumeOutput	KEYWORD2
+
 # Process
 run	KEYWORD2
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -32,6 +32,7 @@ getPattern	KEYWORD2
 getNumLEDs	KEYWORD2
 
 # LED State
+getLastFrame	KEYWORD2
 rewriteFrame	KEYWORD2
 
 # Process

--- a/keywords.txt
+++ b/keywords.txt
@@ -31,6 +31,9 @@ linkPattern	KEYWORD2
 getPattern	KEYWORD2
 getNumLEDs	KEYWORD2
 
+# LED State
+rewriteFrame	KEYWORD2
+
 # Process
 run	KEYWORD2
 

--- a/src/X360ControllerLEDs.cpp
+++ b/src/X360ControllerLEDs.cpp
@@ -109,6 +109,7 @@ void XboxLEDHandler::runFrame() {
 	const LED_Frame & frame = currentAnimation->getFrame(frameIndex);
 	time_frameDuration = frame.Duration * LED_Frame::Timescale;  // Save current frame duration as ms
 	time_frameLast = millis();  // Save time
+	lastLEDFrame = frame.LEDs;  // Save current frame
 	setLEDs(frame.LEDs);  // Set LEDs to current frame
 }
 
@@ -131,6 +132,10 @@ void XboxLEDHandler::run() {
 
 LED_Pattern XboxLEDHandler::getPattern() const {
 	return currentPattern;  // Current pattern as enum
+}
+
+void XboxLEDHandler::rewriteFrame() {
+	setLEDs(lastLEDFrame);  // Re-output with last LED data
 }
 
 

--- a/src/X360ControllerLEDs.cpp
+++ b/src/X360ControllerLEDs.cpp
@@ -134,6 +134,10 @@ LED_Pattern XboxLEDHandler::getPattern() const {
 	return currentPattern;  // Current pattern as enum
 }
 
+uint8_t XboxLEDHandler::getLastFrame() const {
+	return lastLEDFrame;
+}
+
 void XboxLEDHandler::rewriteFrame() {
 	setLEDs(lastLEDFrame);  // Re-output with last LED data
 }

--- a/src/X360ControllerLEDs.cpp
+++ b/src/X360ControllerLEDs.cpp
@@ -110,7 +110,10 @@ void XboxLEDHandler::runFrame() {
 	time_frameDuration = frame.Duration * LED_Frame::Timescale;  // Save current frame duration as ms
 	time_frameLast = millis();  // Save time
 	lastLEDFrame = frame.LEDs;  // Save current frame
-	setLEDs(frame.LEDs);  // Set LEDs to current frame
+
+	if (writeOutput) {
+		setLEDs(frame.LEDs);  // Set LEDs to current frame}
+	}	
 }
 
 void XboxLEDHandler::run() {
@@ -128,6 +131,17 @@ void XboxLEDHandler::run() {
 		frameIndex = 0;  // If at last frame, go to start
 	}
 	runFrame();  // Write current frame to LEDs
+}
+
+void XboxLEDHandler::pauseOutput() {
+	writeOutput = false;
+}
+
+void XboxLEDHandler::resumeOutput() {
+	if (writeOutput == false) {
+		writeOutput = true;
+		rewriteFrame();  // If unpausing, rewrite current LED frame
+	}
 }
 
 LED_Pattern XboxLEDHandler::getPattern() const {

--- a/src/X360ControllerLEDs.h
+++ b/src/X360ControllerLEDs.h
@@ -223,6 +223,9 @@ namespace Xbox360Controller_LEDs {
 
 		uint8_t getLastFrame() const;
 		void rewriteFrame();
+		
+		void pauseOutput();
+		void resumeOutput();
 
 		void run();
 
@@ -236,6 +239,7 @@ namespace Xbox360Controller_LEDs {
 
 		// LED Information
 		boolean linkPatterns = false;
+		boolean writeOutput = true;
 		uint8_t lastLEDFrame = 0x00;  // Bitmap of last LED states
 
 		// Pattern Information (Enum)

--- a/src/X360ControllerLEDs.h
+++ b/src/X360ControllerLEDs.h
@@ -221,6 +221,8 @@ namespace Xbox360Controller_LEDs {
 
 		LED_Pattern getPattern() const;
 
+		void rewriteFrame();
+
 		void run();
 
 	protected:
@@ -233,6 +235,7 @@ namespace Xbox360Controller_LEDs {
 
 		// LED Information
 		boolean linkPatterns = false;
+		uint8_t lastLEDFrame = 0x00;  // Bitmap of last LED states
 
 		// Pattern Information (Enum)
 		LED_Pattern currentPattern;

--- a/src/X360ControllerLEDs.h
+++ b/src/X360ControllerLEDs.h
@@ -221,6 +221,7 @@ namespace Xbox360Controller_LEDs {
 
 		LED_Pattern getPattern() const;
 
+		uint8_t getLastFrame() const;
 		void rewriteFrame();
 
 		void run();


### PR DESCRIPTION
Adds a few functions to allow the user to interrupt the output stream. If the user wants to temporarily take over the output they can call `pauseOutput`, write some data to the LEDs, and when they are ready call `resumeOutput` to have the animation library take back over.

Alternately you can stop calling 'run' to pause the animation execution and output, then call `rewriteFrame` in tandem with 'run' to resume.

Since the last frame state needed to be stored to have `rewriteFrame` work properly, I also added a convenience function to get the last state of the LEDs in packed form (`getLastFrame`).