### PR TITLE
USB XInput Example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,6 @@ install:
 script:
   - buildExampleSketch Blink
   - buildExampleSketch CycleAll
-  - buildExampleSketch USB
   - buildExampleSketch UserOutput
   - if [ "$BOARD" = "arduino:avr:uno" ]; then
       buildExampleSketch InterruptTimer;

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Download the library [here](../../archive/master.zip) and follow [the instructio
 
 Once the library has been installed, load one of the example sketches by going to `File -> Examples -> Xbox 360 Controller LEDs Library` and selecting one of the available examples. I recommend starting with the "Blink" example, which will use your Arduino's built-in LED. Examples that use animations with 4 LEDs will require 4 external LEDs with proper resistors.
 
-**Note**: This library is only for emulating the Xbox 360 controller's **LEDs**. It will **not** make your Arduino work like an Xbox 360 controller. Sorry!
+**Note**: This library is only for emulating the Xbox 360 controller's **LEDs**. It will **not** make your Arduino work like an Xbox 360 controller. For that, you can use [the Arduino XInput library](https://github.com/dmadison/ArduinoXInput).
 
 ## Output Modes
 


### PR DESCRIPTION
Modifies the 'USB' example to work with [the ArduinoXInput library](https://github.com/dmadison/ArduinoXInput). This will work out of the box if used with a supported XInput USB boards package (see the Arduino XInput repo for more information).